### PR TITLE
bugfix/section

### DIFF
--- a/src/components/Section/Section.jsx
+++ b/src/components/Section/Section.jsx
@@ -3,9 +3,8 @@ import PropTypes from 'prop-types'
 const Section = ({title, children, sectionClass, titleClass}) => {
   return (
     <section className={`${sectionClass}`}>
-      <h2 className={`${titleClass}`}>{title}</h2>
-      <div>{children}</div>
-      
+      {title ? <h2 className={`${titleClass}`}>{title}</h2> : null}
+      {children}
     </section>
   )
 }


### PR DESCRIPTION
Deleted unnecessary div
Added ternary operator to h2 because AboutConferent doesn't use it. As a result h2 was appearing in the DOM tree.